### PR TITLE
fix typo in 2020-02-18-brew-no-quarantine.markdown

### DIFF
--- a/_posts/2020-02-18-brew-no-quarantine.markdown
+++ b/_posts/2020-02-18-brew-no-quarantine.markdown
@@ -5,7 +5,7 @@ date:   2020-02-18 00:00:00
 categories: brew mac
 ---
 
-Tired of seeing the Mac Security warning dialog box each time after you installed some `Awesome.app` using `brew`? There is a (semi-)hidden parameter to fix that - `--no-qarantine`, e.g.:
+Tired of seeing the Mac Security warning dialog box each time after you installed some `Awesome.app` using `brew`? There is a (semi-)hidden parameter to fix that - `--no-quarantine`, e.g.:
 
 `brew install --no-quarantine awesome-app`
 


### PR DESCRIPTION
In line 8, `quarantine` was missing a `u`